### PR TITLE
feat: add auth validate endpoint for JWT token validation

### DIFF
--- a/env.example
+++ b/env.example
@@ -7,7 +7,7 @@ PORT=3000
 CORS_ORIGIN=*
 
 # JWT
-JWT_SECRET=your-super-secret-jwt-key-here
+JWT_SECRET=1e29da3142a52df5fe017fcd3a69bc5cd231823d845bfbe0569ba4be0ef67b81
 JWT_EXPIRES_IN=7d
 
 # Redis

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -78,4 +78,24 @@ export class AuthController {
   async getProfile(@Request() req) {
     return req.user;
   }
+
+  @Get('validate')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Validar token de autenticação' })
+  @ApiResponse({
+    status: 200,
+    description: 'Token válido',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Token inválido ou expirado',
+  })
+  async validate(@Request() req) {
+    return {
+      userId: req.user.id,
+      email: req.user.email,
+      isValid: true
+    };
+  }
 }


### PR DESCRIPTION
- Add GET /api/auth/validate route to validate JWT tokens
- Enable inter-service authentication between client and transactions services
- Return user info (userId, email, isValid) for token validation
- Support Bearer token authentication for service-to-service communication