### PR TITLE
feat(client): add Redis cache for client queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/swagger": "^7.4.2",
         "@nestjs/throttler": "^5.1.1",
         "@prisma/client": "^5.19.1",
+        "@types/redis": "^4.0.10",
         "amqplib": "^0.10.9",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
@@ -27,6 +28,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
+        "redis": "^5.8.3",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "swagger-ui-express": "^5.0.1"
@@ -2166,6 +2168,66 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.8.3.tgz",
+      "integrity": "sha512-1eldTzHvdW3Oi0TReb8m1yiFt8ZwyF6rv1NpZyG5R4TpCwuAdKQetBKoCw7D96tNFgsVVd6eL+NaGZZCqhRg4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.3"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.3.tgz",
+      "integrity": "sha512-MZVUE+l7LmMIYlIjubPosruJ9ltSLGFmJqsXApTqPLyHLjsJUSAbAJb/A3N34fEqean4ddiDkdWzNu4ZKPvRUg==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.8.3.tgz",
+      "integrity": "sha512-DRR09fy/u8gynHGJ4gzXYeM7D8nlS6EMv5o+h20ndTJiAc7RGR01fdk2FNjnn1Nz5PjgGGownF+s72bYG4nZKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.3"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.8.3.tgz",
+      "integrity": "sha512-EMIvEeGRR2I0BJEz4PV88DyCuPmMT1rDtznlsHY3cKSDcc9vj0Q411jUnX0iU2vVowUgWn/cpySKjpXdZ8m+5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.3"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.8.3.tgz",
+      "integrity": "sha512-5Jwy3ilsUYQjzpE7WZ1lEeG1RkqQ5kHtwV1p8yxXHSEmyUbC/T/AVgyjMcm52Olj/Ov/mhDKjx6ndYUi14bXsw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.3"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2546,6 +2608,15 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/redis": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-4.0.10.tgz",
+      "integrity": "sha512-7CLy5b5fzzEGVcOccgZjoMlNpPhX6d10jEeRy2YWbFuaMNrSPc9ExRsMYsd+0VxvEHucf4EWx24Ja7cSU1FGUA==",
+      "license": "MIT",
+      "dependencies": {
+        "redis": "*"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -4020,6 +4091,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -8540,6 +8620,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.8.3.tgz",
+      "integrity": "sha512-MfSrfV6+tEfTw8c4W0yFp6XWX8Il4laGU7Bx4kvW4uiYM1AuZ3KGqEGt1LdQHeD1nEyLpIWetZ/SpY3kkbgrYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.8.3",
+        "@redis/client": "5.8.3",
+        "@redis/json": "5.8.3",
+        "@redis/search": "5.8.3",
+        "@redis/time-series": "5.8.3"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@nestjs/swagger": "^7.4.2",
     "@nestjs/throttler": "^5.1.1",
     "@prisma/client": "^5.19.1",
+    "@types/redis": "^4.0.10",
     "amqplib": "^0.10.9",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
@@ -43,6 +44,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
+    "redis": "^5.8.3",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1"

--- a/src/common/redis/redis.module.ts
+++ b/src/common/redis/redis.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { RedisService } from './redis.service';
+
+@Global()
+@Module({
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class RedisModule {}

--- a/src/common/redis/redis.service.ts
+++ b/src/common/redis/redis.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createClient, RedisClientType } from 'redis';
+
+@Injectable()
+export class RedisService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(RedisService.name);
+  private client: RedisClientType;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async onModuleInit() {
+    const redisUrl = this.configService.get<string>('REDIS_URL', 'redis://localhost:6379');
+    
+    this.client = createClient({
+      url: redisUrl,
+    });
+
+    this.client.on('error', (err) => {
+      this.logger.error(`Redis connection error: ${err.message}`);
+    });
+
+    this.client.on('connect', () => {
+      this.logger.log('Redis connected');
+    });
+
+    this.client.on('ready', () => {
+      this.logger.log('Redis ready');
+    });
+
+    await this.client.connect();
+  }
+
+  async onModuleDestroy() {
+    if (this.client) {
+      await this.client.quit();
+      this.logger.log('Redis disconnected');
+    }
+  }
+
+  async get(key: string): Promise<string | null> {
+    try {
+      const result = await this.client.get(key);
+      return result as string | null;
+    } catch (error) {
+      this.logger.error(`Redis get error for key ${key}: ${error?.message}`);
+      return null;
+    }
+  }
+
+  async set(key: string, value: string, ttlSeconds?: number): Promise<boolean> {
+    try {
+      if (ttlSeconds) {
+        await this.client.setEx(key, ttlSeconds, value);
+      } else {
+        await this.client.set(key, value);
+      }
+      return true;
+    } catch (error) {
+      this.logger.error(`Redis set error for key ${key}: ${error?.message}`);
+      return false;
+    }
+  }
+
+  async del(key: string): Promise<boolean> {
+    try {
+      await this.client.del(key);
+      return true;
+    } catch (error) {
+      this.logger.error(`Redis del error for key ${key}: ${error?.message}`);
+      return false;
+    }
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      const result = await this.client.exists(key);
+      return result === 1;
+    } catch (error) {
+      this.logger.error(`Redis exists error for key ${key}: ${error?.message}`);
+      return false;
+    }
+  }
+}

--- a/src/modules/client/client.module.ts
+++ b/src/modules/client/client.module.ts
@@ -3,10 +3,11 @@ import { ClientService } from './client.service';
 import { ClientController } from './client.controller';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { RabbitMQModule } from '../../rabbitmq/rabbitmq.module';
+import { RedisModule } from '../../common/redis/redis.module';
 import { TransactionsConsumer } from './transactions.consumer';
 
 @Module({
-  imports: [RabbitMQModule],
+  imports: [RabbitMQModule, RedisModule],
   controllers: [ClientController],
   providers: [ClientService, PrismaService, TransactionsConsumer],
   exports: [ClientService],

--- a/src/modules/client/client.service.ts
+++ b/src/modules/client/client.service.ts
@@ -1,12 +1,16 @@
 import { Injectable, NotFoundException, ConflictException, BadRequestException, InternalServerErrorException, Logger } from '@nestjs/common';
 import { PrismaService } from '../../common/prisma/prisma.service';
+import { RedisService } from '../../common/redis/redis.service';
 import { CreateClientDto, UpdateClientDto, FilterClientDto, UpdateProfilePictureDto, UpdateBalanceDto } from './dto';
 import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class ClientService {
   private readonly logger = new Logger(ClientService.name);
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redis: RedisService
+  ) {}
 
   async create(createClientDto: CreateClientDto) {
     try {
@@ -93,6 +97,16 @@ export class ClientService {
   async findOne(id: string) {
     try {
       const startedAt = Date.now();
+      const cacheKey = `client:${id}`;
+      
+      // Try to get from cache first
+      const cachedClient = await this.redis.get(cacheKey);
+      if (cachedClient) {
+        this.logger.log(`get:cache_hit id=${id} durationMs=${Date.now() - startedAt}`);
+        return JSON.parse(cachedClient);
+      }
+
+      this.logger.log(`get:cache_miss id=${id}`);
       const client = await this.prisma.client.findUnique({
         where: { id },
         select: {
@@ -113,6 +127,9 @@ export class ClientService {
         this.logger.warn(`get:not_found id=${id}`);
         throw new NotFoundException('Client not found');
       }
+
+      // Cache the result for 5 minutes (300 seconds)
+      await this.redis.set(cacheKey, JSON.stringify(client), 300);
       this.logger.log(`get:ok id=${id} durationMs=${Date.now() - startedAt}`);
       return client;
     } catch (error) {
@@ -155,6 +172,8 @@ export class ClientService {
           updatedAt: true,
         },
       });
+      // Invalidate cache
+      await this.redis.del(`client:${id}`);
       this.logger.log(`update:ok id=${id} durationMs=${Date.now() - startedAt}`);
       return client;
     } catch (error) {
@@ -182,6 +201,8 @@ export class ClientService {
       await this.prisma.client.delete({
         where: { id },
       });
+      // Invalidate cache
+      await this.redis.del(`client:${id}`);
       this.logger.log(`delete:ok id=${id} durationMs=${Date.now() - startedAt}`);
       return { message: 'Cliente removido com sucesso' };
     } catch (error) {
@@ -236,6 +257,8 @@ export class ClientService {
           updatedAt: true,
         },
       });
+      // Invalidate cache
+      await this.redis.del(`client:${id}`);
       this.logger.log(`updateProfilePicture:ok id=${id} durationMs=${Date.now() - startedAt}`);
       return client;
     } catch (error) {


### PR DESCRIPTION
- Add RedisService with connection management and error handling
- Implement cache in ClientService.findOne() with 5min TTL
- Add cache invalidation on update/delete/updateProfilePicture
- Add structured logging for cache hits/misses
- Install redis and @types/redis dependencies
- Improve performance for frequent client lookups